### PR TITLE
修正拼接get请求时会多移除最后一位的bug

### DIFF
--- a/Apollo/Util/QueryUtils.cs
+++ b/Apollo/Util/QueryUtils.cs
@@ -21,7 +21,7 @@ namespace Com.Ctrip.Framework.Apollo.Util
                 sb.Append(WebUtility.UrlEncode(kv.Value));
             }
 
-            return sb.ToString(0, sb.Length - 1);
+            return sb.ToString(0, sb.Length);
         }
     }
 }


### PR DESCRIPTION
因为将 & 符号写在最前面，所以在24行转换为string时不需要移除最后一位