### PR TITLE
修复拼接查询参数时会多加一个&符号和多移除最后一位的bug

### DIFF
--- a/Apollo/Util/QueryUtils.cs
+++ b/Apollo/Util/QueryUtils.cs
@@ -11,6 +11,10 @@ namespace Com.Ctrip.Framework.Apollo.Util
     {
         public static string Build(IReadOnlyCollection<KeyValuePair<string, string>> source)
         {
+            if (source == null || source.Count == 0)
+            {
+                return "";
+            }
             var sb = new StringBuilder(source.Count * 32);
 
             foreach (var kv in source)
@@ -21,7 +25,7 @@ namespace Com.Ctrip.Framework.Apollo.Util
                 sb.Append(WebUtility.UrlEncode(kv.Value));
             }
 
-            return sb.ToString(0, sb.Length - 1);
+            return sb.ToString(1, sb.Length - 1);
         }
     }
 }


### PR DESCRIPTION
假设api地址为http://192.168.1.1/api，客户端ip为192.168.1.203
修改前拼接的url如下：http://192.168.1.1/api?&ip=192.168.1.20
修改后拼接的url如下：http://192.168.1.1/api?ip=192.168.1.203