### PR TITLE
Apollo.ConfigurationManager 修复Env大小写敏感

### DIFF
--- a/Apollo.ConfigurationManager/Util/ConfigUtil.cs
+++ b/Apollo.ConfigurationManager/Util/ConfigUtil.cs
@@ -107,7 +107,7 @@ namespace Com.Ctrip.Framework.Apollo.Util
         /// Get the current environment.
         /// </summary>
         /// <returns> the env </returns>
-        public Env Env => Enum.TryParse(GetAppConfig("Env"), out Env env) ? env : Env.Dev;
+        public Env Env => Enum.TryParse(GetAppConfig("Env"), true, out Env env) ? env : Env.Dev;
 
         public string LocalIp { get; set; } = NetworkInterfaceManager.HostIp;
 


### PR DESCRIPTION
文档写的是不敏感大小写, 实际是敏感的. 