### PR TITLE
解决Docker环境部署Apollo后使用.Net客户端访问获取IP为Docker内部IP问题

### DIFF
--- a/Apollo/Internals/RemoteConfigRepository.cs
+++ b/Apollo/Internals/RemoteConfigRepository.cs
@@ -123,6 +123,11 @@ namespace Com.Ctrip.Framework.Apollo.Internals
 
                 foreach (var configService in randomConfigServices)
                 {
+                    if (!string.IsNullOrEmpty(_options.MetaServer))
+                    {
+                        configService.HomepageUrl = _options.MetaServer;
+                    }
+
                     url = AssembleQueryConfigUrl(configService.HomepageUrl, appId, cluster, Namespace, dataCenter, _remoteMessages, _configCache);
 
                     Logger().Debug($"Loading config from {url}");


### PR DESCRIPTION
原因是请求http://47.111.XXX.XXX:8080/services/config接口返回的是Docker内网的homepageUrl，完整的返回数据
[{"appName":"APOLLO-CONFIGSERVICE","instanceId":"6cd0279a50a8:apollo-configservice:8080","homepageUrl":"http://192.168.112.3:8080/"}]
